### PR TITLE
Fix for breaking shadertoy update.

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -32,12 +32,10 @@
 
     function parseText(text) {
         return new Promise((resolve) => {
-            var fragment = text.match(/var gShaderIDs=\[".*"]/)[0].replace('var gShaderIDs=', ''),
-                jsonData = {};
+            var shaders = text.match(/var gShaders=\[[^]*?(?=var gUseScreenshots)/gm)[0].match(/(?<=info":{"id":")[a-zA-Z0-9]{5,}(?=")/g)
 
             try {
-                jsonData = JSON.parse(fragment);
-                resolve(jsonData);
+                resolve(shaders);
             } catch (ignore) {
             }
         });


### PR DESCRIPTION
gShaderIDs array was removed. 
gShaders is now a huge js object which fails to be JSON.parse()d, so I regex match the shader id.